### PR TITLE
Implement multi-memo support

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,7 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.0.6/schema.json",
   "files": {
-    "ignoreUnknown": false,
-    "ignore": ["dist/**/*", "node_modules/**/*"]
+    "ignoreUnknown": false
   },
   "formatter": {
     "enabled": true,

--- a/biome.json
+++ b/biome.json
@@ -18,5 +18,10 @@
     "formatter": {
       "quoteStyle": "double"
     }
+  },
+  "css": {
+    "parser": {
+      "cssModules": true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@tiptap/extension-character-count": "^2.23.0",
     "@tiptap/react": "^2.23.0",
     "@tiptap/starter-kit": "^2.23.0",
+    "dexie": "^3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router-dom": "^7.6.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^2.23.0
         version: 2.23.0
+      dexie:
+        specifier: ^3
+        version: 3.2.7
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -1030,6 +1033,10 @@ packages:
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
     engines: {node: '>=8'}
+
+  dexie@3.2.7:
+    resolution: {integrity: sha512-2a+BXvVhY5op+smDRLxeBAivE7YcYaneXJ1la3HOkUfX9zKkE/AJ8CNgjiXbtXepFyFmJNGSbmjOwqbT749r/w==}
+    engines: {node: '>=6.0'}
 
   electron-to-chromium@1.5.177:
     resolution: {integrity: sha512-7EH2G59nLsEMj97fpDuvVcYi6lwTcM1xuWw3PssD8xzboAW7zj7iB3COEEEATUfjLHrs5uKBLQT03V/8URx06g==}
@@ -2202,6 +2209,8 @@ snapshots:
   defu@6.1.4: {}
 
   detect-libc@2.0.4: {}
+
+  dexie@3.2.7: {}
 
   electron-to-chromium@1.5.177: {}
 

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   align-items: center;
   padding: 2rem;
-  font-family: 'Roboto', sans-serif; /* Modern font */
+  font-family: "Roboto", sans-serif; /* Modern font */
   background-color: #f0f2f5; /* Light grey background */
   min-height: 100vh;
   box-sizing: border-box; /* Ensures padding doesn't add to width/height */
@@ -45,7 +45,6 @@
   margin-bottom: 0; /* Remove default bottom margin from last paragraph */
 }
 
-
 .editorContent :global(.ProseMirror:focus) {
   border-color: #5e72e4; /* A modern, friendly blue */
   box-shadow: 0 0 0 0.2rem rgba(94, 114, 228, 0.25); /* Matching focus shadow */
@@ -69,7 +68,8 @@
   font-weight: 500; /* Medium weight for clarity */
 }
 
-.statItem span { /* If you want to style a label and value differently */
+.statItem span {
+  /* If you want to style a label and value differently */
   font-weight: 400;
   color: #8898aa;
 }

--- a/src/App.module.css
+++ b/src/App.module.css
@@ -73,3 +73,52 @@
   font-weight: 400;
   color: #8898aa;
 }
+
+.layout {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 250px;
+  background-color: #ffffff;
+  box-shadow: 2px 0 5px rgba(0, 0, 0, 0.1);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+}
+
+.memoList {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
+}
+
+.memoCard {
+  background-color: #f7f7f7;
+  padding: 0.5rem;
+  border-radius: 4px;
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+}
+
+.memoCardActive {
+  background-color: #e0e7ff;
+}
+
+.newButton {
+  margin-top: 1rem;
+  padding: 0.5rem;
+  background-color: #5e72e4;
+  color: #ffffff;
+  text-align: center;
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+.content {
+  flex: 1;
+  padding: 2rem;
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,31 +1,14 @@
-import CharacterCount from "@tiptap/extension-character-count";
-import { EditorContent, useEditor } from "@tiptap/react";
-import StarterKit from "@tiptap/starter-kit";
-import { useState } from "react";
+import { Outlet } from "react-router-dom";
+import Sidebar from "./Sidebar";
 import styles from "./App.module.css";
 
-function App() {
-  const [character, setCharacter] = useState("Hello World! 🌎️");
-  const editor = useEditor({
-    extensions: [StarterKit, CharacterCount],
-    content: character,
-    onUpdate: ({ editor }) => {
-      setCharacter(editor.getText());
-    },
-  });
-
+export default function App() {
   return (
-    <div className={styles.container}>
-      <h1 className={styles.header}>Moji - Character Counter</h1>
-      <div className={styles.editorContainer}>
-        <EditorContent editor={editor} className={styles.editorContent} />
-      </div>
-      <div className={styles.stats}>
-        <p className={styles.statItem}>Characters: {character.length}</p>
-        <p className={styles.statItem}>Words: {character.split(" ").length}</p>
+    <div className={styles.layout}>
+      <Sidebar />
+      <div className={styles.content}>
+        <Outlet />
       </div>
     </div>
   );
 }
-
-export default App;

--- a/src/MemoEditor.tsx
+++ b/src/MemoEditor.tsx
@@ -1,0 +1,73 @@
+import CharacterCount from "@tiptap/extension-character-count";
+import { EditorContent, useEditor } from "@tiptap/react";
+import StarterKit from "@tiptap/starter-kit";
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { db } from "./db";
+import styles from "./App.module.css";
+
+interface Props {
+  memoId?: string;
+  initialContent?: string;
+  onCreate?: (id: string) => void;
+}
+
+function useDebouncedEffect(fn: () => void, deps: unknown[], delay: number) {
+  useEffect(() => {
+    const handle = setTimeout(fn, delay);
+    return () => clearTimeout(handle);
+  }, [...deps, delay]);
+}
+
+export default function MemoEditor({ memoId, initialContent = "", onCreate }: Props) {
+  const navigate = useNavigate();
+  const [id, setId] = useState<string | undefined>(memoId);
+  const [content, setContent] = useState(initialContent);
+  const isComposing = useRef(false);
+
+  const editor = useEditor({
+    extensions: [StarterKit, CharacterCount],
+    content: initialContent,
+    onUpdate: ({ editor }) => {
+      const html = editor.getHTML();
+      setContent(html);
+    },
+  });
+
+  useDebouncedEffect(() => {
+    if (!editor || isComposing.current) return;
+    const now = Date.now();
+    if (!id) {
+      const newId = crypto.randomUUID();
+      setId(newId);
+      db.memos.put({ id: newId, content, createdAt: now, updatedAt: now });
+      onCreate?.(newId);
+      navigate(`/memo/${newId}`, { replace: true });
+    } else {
+      db.memos.put({ id, content, createdAt: now, updatedAt: now });
+    }
+  }, [content, id], 500);
+
+  return (
+    <div className={styles.container}>
+      <h1 className={styles.header}>Moji - Character Counter</h1>
+      <div className={styles.editorContainer}>
+        <EditorContent
+          editor={editor}
+          className={styles.editorContent}
+          onCompositionStart={() => {
+            isComposing.current = true;
+          }}
+          onCompositionEnd={() => {
+            isComposing.current = false;
+            setContent(editor?.getHTML() ?? "");
+          }}
+        />
+      </div>
+      <div className={styles.stats}>
+        <p className={styles.statItem}>Characters: {editor?.storage.characterCount.characters()}</p>
+        <p className={styles.statItem}>Words: {editor?.storage.characterCount.words()}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/MemoEditor.tsx
+++ b/src/MemoEditor.tsx
@@ -19,7 +19,11 @@ function useDebouncedEffect(fn: () => void, deps: unknown[], delay: number) {
   }, [...deps, delay]);
 }
 
-export default function MemoEditor({ memoId, initialContent = "", onCreate }: Props) {
+export default function MemoEditor({
+  memoId,
+  initialContent = "",
+  onCreate,
+}: Props) {
   const navigate = useNavigate();
   const [id, setId] = useState<string | undefined>(memoId);
   const [content, setContent] = useState(initialContent);
@@ -34,19 +38,23 @@ export default function MemoEditor({ memoId, initialContent = "", onCreate }: Pr
     },
   });
 
-  useDebouncedEffect(() => {
-    if (!editor || isComposing.current) return;
-    const now = Date.now();
-    if (!id) {
-      const newId = crypto.randomUUID();
-      setId(newId);
-      db.memos.put({ id: newId, content, createdAt: now, updatedAt: now });
-      onCreate?.(newId);
-      navigate(`/memo/${newId}`, { replace: true });
-    } else {
-      db.memos.put({ id, content, createdAt: now, updatedAt: now });
-    }
-  }, [content, id], 500);
+  useDebouncedEffect(
+    () => {
+      if (!editor || isComposing.current) return;
+      const now = Date.now();
+      if (!id) {
+        const newId = crypto.randomUUID();
+        setId(newId);
+        db.memos.put({ id: newId, content, createdAt: now, updatedAt: now });
+        onCreate?.(newId);
+        navigate(`/memo/${newId}`, { replace: true });
+      } else {
+        db.memos.put({ id, content, createdAt: now, updatedAt: now });
+      }
+    },
+    [content, id],
+    500,
+  );
 
   return (
     <div className={styles.container}>
@@ -65,8 +73,12 @@ export default function MemoEditor({ memoId, initialContent = "", onCreate }: Pr
         />
       </div>
       <div className={styles.stats}>
-        <p className={styles.statItem}>Characters: {editor?.storage.characterCount.characters()}</p>
-        <p className={styles.statItem}>Words: {editor?.storage.characterCount.words()}</p>
+        <p className={styles.statItem}>
+          Characters: {editor?.storage.characterCount.characters()}
+        </p>
+        <p className={styles.statItem}>
+          Words: {editor?.storage.characterCount.words()}
+        </p>
       </div>
     </div>
   );

--- a/src/MemoPage.tsx
+++ b/src/MemoPage.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import MemoEditor from "./MemoEditor";
+import { db } from "./db";
+
+export default function MemoPage() {
+  const { memoId } = useParams();
+  const [content, setContent] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!memoId) return;
+    db.memos.get(memoId).then((m) => {
+      setContent(m?.content ?? "");
+    });
+  }, [memoId]);
+
+  if (content === null) {
+    return null;
+  }
+
+  return <MemoEditor memoId={memoId} initialContent={content} />;
+}

--- a/src/NewMemoPage.tsx
+++ b/src/NewMemoPage.tsx
@@ -1,0 +1,5 @@
+import MemoEditor from "./MemoEditor";
+
+export default function NewMemoPage() {
+  return <MemoEditor />;
+}

--- a/src/Sidebar.tsx
+++ b/src/Sidebar.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
+import { liveQuery } from "dexie";
+import { db } from "./db";
+import type { Memo } from "./db";
+import styles from "./App.module.css";
+
+function extractTitle(html: string): string {
+  const div = document.createElement("div");
+  div.innerHTML = html;
+  const text = div.textContent || "";
+  return text.trim().slice(0, 20) || "(no content)";
+}
+
+export default function Sidebar() {
+  const location = useLocation();
+  const [memos, setMemos] = useState<Memo[]>([]);
+
+  useEffect(() => {
+    const sub = liveQuery(() =>
+      db.memos.orderBy("updatedAt").reverse().toArray(),
+    ).subscribe({ next: setMemos });
+    return () => sub.unsubscribe();
+  }, []);
+
+  return (
+    <div className={styles.sidebar}>
+      <div className={styles.memoList}>
+        {memos.map((m) => (
+          <Link
+            key={m.id}
+            to={`/memo/${m.id}`}
+            className={`${styles.memoCard} ${
+              location.pathname === `/memo/${m.id}` ? styles.memoCardActive : ""
+            }`}
+          >
+            <div>{extractTitle(m.content)}</div>
+            <small>{new Date(m.updatedAt).toLocaleString()}</small>
+          </Link>
+        ))}
+      </div>
+      <Link to="/new" className={styles.newButton}>
+        + New
+      </Link>
+    </div>
+  );
+}

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,0 +1,22 @@
+import Dexie from "dexie";
+import type { Table } from "dexie";
+
+export interface Memo {
+  id: string;
+  content: string;
+  updatedAt: number;
+  createdAt: number;
+}
+
+class MemoDB extends Dexie {
+  memos!: Table<Memo, string>;
+
+  constructor() {
+    super("memoDB");
+    this.version(1).stores({
+      memos: "&id, updatedAt, createdAt",
+    });
+  }
+}
+
+export const db = new MemoDB();

--- a/src/index.css
+++ b/src/index.css
@@ -1,9 +1,9 @@
 /* Global Styles */
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
-    'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
+    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: #f0f2f5; /* Default background for the whole page */
@@ -14,7 +14,9 @@ html {
   box-sizing: border-box;
 }
 
-*, *:before, *:after {
+*,
+*:before,
+*:after {
   box-sizing: inherit;
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,20 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { RouterProvider, createBrowserRouter } from "react-router-dom";
-import App from "./App.tsx";
-import "./index.css"; // Import global styles
+import { RouterProvider, createBrowserRouter, Navigate } from "react-router-dom";
+import App from "./App";
+import NewMemoPage from "./NewMemoPage";
+import MemoPage from "./MemoPage";
+import "./index.css";
 
 const router = createBrowserRouter([
   {
     path: "/",
     element: <App />,
+    children: [
+      { index: true, element: <Navigate to="/new" replace /> },
+      { path: "new", element: <NewMemoPage /> },
+      { path: "memo/:memoId", element: <MemoPage /> },
+    ],
   },
 ]);
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,6 +1,10 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { RouterProvider, createBrowserRouter, Navigate } from "react-router-dom";
+import {
+  RouterProvider,
+  createBrowserRouter,
+  Navigate,
+} from "react-router-dom";
 import App from "./App";
 import NewMemoPage from "./NewMemoPage";
 import MemoPage from "./MemoPage";

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,0 +1,16 @@
+export interface Env {
+  ASSETS: {
+    fetch(request: Request): Promise<Response>;
+  };
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const res = await env.ASSETS.fetch(request);
+    const accept = request.headers.get("Accept") || "";
+    if (res.status === 404 && request.method === "GET" && accept.includes("text/html")) {
+      return env.ASSETS.fetch(new Request("/index.html", request));
+    }
+    return res;
+  },
+};

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -8,7 +8,11 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const res = await env.ASSETS.fetch(request);
     const accept = request.headers.get("Accept") || "";
-    if (res.status === 404 && request.method === "GET" && accept.includes("text/html")) {
+    if (
+      res.status === 404 &&
+      request.method === "GET" &&
+      accept.includes("text/html")
+    ) {
       return env.ASSETS.fetch(new Request("/index.html", request));
     }
     return res;

--- a/wrangler.json
+++ b/wrangler.json
@@ -1,6 +1,7 @@
 {
   "name": "moji",
   "compatibility_date": "2025-07-04",
+  "main": "src/worker.ts",
   "assets": {
     "directory": "./dist/"
   }


### PR DESCRIPTION
## Summary
- store memo documents in IndexedDB using Dexie
- add sidebar to switch between memos
- implement editor component that autosaves with IME aware debounce
- add router paths for `/new` and `/memo/:memoId`

## Testing
- `pnpm run lint` *(fails: `:local` CSS parsing errors)*
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_6867862a6e54832fb18c029b33ce1d65